### PR TITLE
Discard GREP_OPTIONS in case its set to not have parse errors.

### DIFF
--- a/sandboxd
+++ b/sandboxd
@@ -23,7 +23,7 @@ function sandbox_delete_hooks(){
 function sandbox(){
   local cmd=$1
 
-   if [[ "$(type $cmd | grep -o function)" = "function" ]]; then
+   if [[ "$(type $cmd | GREP_OPTIONS= grep -o function)" = "function" ]]; then
     (>&2 echo "sandboxing $cmd ...")
     sandbox_delete_hooks $cmd
     sandbox_init_$cmd # run user-defined sandbox
@@ -48,7 +48,7 @@ source "$SANDBOXRC"
 
 # create hooks for the sandbox names themselves
 function sandbox_initialise(){
-  local funcs="$( cat $SANDBOXRC | sed 's/#.*$//g' | grep -o 'sandbox_init_[^(]\+' )"
+  local funcs="$( cat $SANDBOXRC | sed 's/#.*$//g' | GREP_OPTIONS= grep -o 'sandbox_init_[^(]\+' )"
   while read f; do
     local cmd=$(echo $f | sed s/sandbox_init_//)
     sandbox_hook $cmd $cmd;


### PR DESCRIPTION
I have my `GREP_OPTIONS` set to the following - which messes up the `grep` command used within your scripts. 
`export GREP_OPTIONS="-Hn --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn}"`

To overcome the parse errors, this PR will override the `GREP_OPTIONS` locally before each `grep` command.