### PR TITLE
Add automatic shim loading capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,40 @@ This might be useful if you want to run a sandbox that doesn't have an associate
 sandbox rvm
 sandbox nvm
 ```
+
+# Shims
+Tools like [pyenv](https://github.com/pyenv/pyenv), [rbenv](https://github.com/rbenv/rbenv), [nodenv](https://github.com/nodenv/nodenv) etc use the concept of ['shims'](https://github.com/pyenv/pyenv#understanding-shims), which are helper scripts created when installed packages create command line utilities (e.g. installing the AWS CLI via Pip creates the `aws` command). To make it easy for sandboxd to lazy-load these environments when any of these 'shims' are called, use the function `sandbox_hook_shims {<name>} [<dir>]`. See [sandboxrc.example.pyenv](sandboxrc.example.pyenv) for more information.
+
+Example:
+Shims created under `~/.pyenv/shims/`
+```bash
+$ ls -l ~/.pyenv/shims
+ansible
+ansible-config
+aws
+flask
+[...]
+```
+
+To automatically add them all as a sandboxd `hook`, simply add the following to `.sandboxrc`:
+```bash
+# in ~/.sandboxrc
+
+sandbox_init_pyenv() {
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  export VIRTUAL_ENV_DISABLE_PROMPT=1
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+}
+
+sandbox_hook_shims pyenv
+```
+
+Here, the `pyenv` argument of `sandbox_hook_shims` matches the function name defined above (`sandbox_init_pyenv`).
+`sandbox_hook_shims` assumes the shim directory to be `~/.<name>/shims` where `<name>` is the first argument. If the diretory is different, pass it as an argument:
+
+```bash
+sandbox_hook_shims pyenv /path/to/shim/directory
+```
+

--- a/sandboxd
+++ b/sandboxd
@@ -33,6 +33,7 @@ function sandbox(){
   fi
 }
 
+# adds hooks to sandboxes
 function sandbox_hook(){
   local cmd=$1
   local hook=$2
@@ -41,8 +42,17 @@ function sandbox_hook(){
   eval "$hook(){ sandbox $cmd; $hook \$@ ; }"
 }
 
-
-
+# automatically add hooks for shims of virtualenvs, e.g. pyenv, rbenv, etc
+# optionally pass the shim directory, assumed to be $HOME/.<command>/shims
+function sandbox_hook_shims(){
+  local cmd=$1
+  local dir="${2:-$HOME/.$1/shims}"
+  if test -d $dir; then
+    for shim in $(ls $dir); do
+      sandbox_hook $1 $shim
+    done
+  fi
+}
 
 source "$SANDBOXRC"
 

--- a/sandboxrc.example.pyenv
+++ b/sandboxrc.example.pyenv
@@ -1,0 +1,18 @@
+sandbox_init_pyenv() {
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  export VIRTUAL_ENV_DISABLE_PROMPT=1
+  eval "$(pyenv init -)"
+  eval "$(pyenv virtualenv-init -)"
+}
+
+sandbox_init_ruby() {
+  export RBENV_ROOT="$HOME/.rbenv"
+  export PATH="$RBENV_ROOT/bin:$PATH"
+  export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@1.1)"
+  eval "$(rbenv init -)"
+}
+
+sandbox_hook_shims pyenv
+sandbox_hook_shims ruby "$HOME/.rbenv/shims"
+


### PR DESCRIPTION
I added a new function to `sandboxd` called `sandbox_hook_shims` to automatically create hooks to `shimmed` scripts, which are created by some virtual env managers.

Please let me know if you'd like me to change this implementation or have any suggestions.