### PR TITLE
Check if hook function exist before unset in case of duplicates

### DIFF
--- a/sandboxd
+++ b/sandboxd
@@ -12,10 +12,10 @@ function sandbox_delete_hooks(){
   do
     if [[ $i == "${cmd}:"* ]]; then
      local hook=$(echo $i | sed "s/.*://")
-     unset -f "$hook"
+     # Check if this is still a function, as it could have been unset alrady in case of duplicates.
+     typeset -f "$hook" >/dev/null && unset -f "$hook"
     fi
   done
-
 }
 
 


### PR DESCRIPTION
In the case of multiple executables have been sandboxed e.g. via a
multiple shim setup, the code used to try to unset the same hook
multiple times. With this patch, check if the hook is still there before
doing the unset.

I've tested this patch with zsh (5.8) and bash (5.1.8) and it works on
both. Refering to this thread on how to test for function existance in a
way that works for both zsh and bash: https://unix.stackexchange.com/a/332047/19909

See #12 for example that triggers the bug that this patches solves.

Fixes #12