### PR TITLE
Add support for $XDG_CONFIG_HOME for sandboxrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,9 @@ Here, the `pyenv` argument of `sandbox_hook_shims` matches the function name def
 sandbox_hook_shims pyenv /path/to/shim/directory
 ```
 
+## sandboxrc configuration file
+The location of the configuration file depends on the environment's configuration. The file is searched in the following order:
+
+1. `$SANDBOXRC` -  if it is set. This has highest precedence. Thus you can set this to override to custom location.
+1. `$XDG_CONFIG_HOME/sandboxd/sandboxrc` - if the directory `sandboxd/` exist. Note that `$XDG_CONFIG_HOME` defaults to `$HOME/.config`
+1. `$HOME/.sandboxrc` - fall back to old default location.

--- a/sandboxd
+++ b/sandboxd
@@ -38,7 +38,7 @@ function sandbox(){
     sandbox_delete_hooks $cmd
     sandbox_init_$cmd # run user-defined sandbox
   else
-    (>&2 echo "sandbox '$cmd' not found.\nHave you defined sandbox_init_$cmd(){ ... } in your sandboxrc?")
+    (>&2 echo "sandbox '$cmd' not found.\nHave you defined sandbox_init_$cmd(){ ... } in your sandboxrc (${RC_FILE})?")
     return 1
   fi
 }

--- a/sandboxd
+++ b/sandboxd
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-: ${SANDBOXRC:="$HOME/.sandboxrc"}
+function sandbox_get_config_file() {
+  if  ! [ -z ${SANDBOXRC+x} ]; then
+    echo "$SANDBOXRC"
+  elif [ -d ${XDG_CONFIG_HOME:-$HOME/.config}/sandboxd ]; then
+    echo "${XDG_CONFIG_HOME:-$HOME/.config}/sandboxd/sandboxrc"
+  else
+    echo "${HOME}/.sandboxrc"
+  fi
+}
+
+typeset -r RC_FILE="$(sandbox_get_config_file)"
 
 # holds all hook descriptions in "cmd:hook" format
 sandbox_hooks=()
@@ -28,7 +38,7 @@ function sandbox(){
     sandbox_delete_hooks $cmd
     sandbox_init_$cmd # run user-defined sandbox
   else
-    (>&2 echo "sandbox '$cmd' not found.\nHave you defined sandbox_init_$cmd(){ ... } in your ~/.sandboxrc?")
+    (>&2 echo "sandbox '$cmd' not found.\nHave you defined sandbox_init_$cmd(){ ... } in your sandboxrc?")
     return 1
   fi
 }
@@ -54,11 +64,11 @@ function sandbox_hook_shims(){
   fi
 }
 
-source "$SANDBOXRC"
+source "$RC_FILE"
 
 # create hooks for the sandbox names themselves
 function sandbox_initialise(){
-  local funcs="$( cat $SANDBOXRC | sed 's/#.*$//g' | GREP_OPTIONS= grep -o 'sandbox_init_[^(]\+' )"
+  local funcs="$( cat $RC_FILE | sed 's/#.*$//g' | GREP_OPTIONS= grep -o 'sandbox_init_[^(]\+' )"
   while read f; do
     local cmd=$(echo $f | sed s/sandbox_init_//)
     sandbox_hook $cmd $cmd;


### PR DESCRIPTION
The location of the configuration file depends on the environment's configuration. The file is searched in the following order:

1. `$SANDBOXRC` -  if it is set. This has highest precedence. Thus you can set this to override to custom location.
1. `$XDG_CONFIG_HOME/sandboxd/sandboxrc` - if the directory `sandboxd/` exist. Note that `$XDG_CONFIG_HOME` defaults to `$HOME/.config`
1. `$HOME/.sandboxrc` - fall back to old default location.


Fixes #11 
